### PR TITLE
Update bscols widths example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ sample_content %>%
 ### search & filter
 
 ```{r search-and-filter}
-bscols(rscsearch(all_content), rscfilter(all_content), widths = c(2, 2))
+bscols(rscsearch(all_content), rscfilter(all_content), widths = c(3, NA))
 rsctable(all_content)
 ```
 ````

--- a/inst/rmarkdown/templates/connectwidgets/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/connectwidgets/skeleton/skeleton.Rmd
@@ -51,6 +51,6 @@ sample_content %>%
 ### search & filter
 
 ```{r search-and-filter}
-bscols(rscsearch(all_content), rscfilter(all_content), widths = c(2, 2))
+bscols(rscsearch(all_content), rscfilter(all_content), widths = c(3, NA))
 rsctable(all_content)
 ```


### PR DESCRIPTION
@edavidaja the default example of (2,2) is giving me this 

<img width="239" alt="Screen Shot 2021-06-04 at 12 40 09 AM" src="https://user-images.githubusercontent.com/4359210/120765667-4bdcca00-c4ce-11eb-9773-c761a8eea4f7.png">

What do you think about updating it to (3, NA)?
