### PR TITLE
warn rather than err when the server does not provide version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# connectwidgets unreleased
+
+* Warn rather than err when the server version is not available. (#63)
+
 # connectwidgets 0.1.1
 
 * Initial public release and CRAN submission of the {connectwidgets} R package

--- a/R/connect.R
+++ b/R/connect.R
@@ -81,7 +81,15 @@ Client <- R6::R6Class( # nolint
         }
       )
 
-      if (compareVersion(settings$version, self$minimum_server_version) < 0) {
+      if (identical(settings$version, "")) {
+        warning(
+          glue::glue(
+            "Unable to validate that the RStudio Connect server version >= ",
+            self$minimum_server_version,
+            "; the server did not provide its version."
+          )
+        )
+      } else if (compareVersion(settings$version, self$minimum_server_version) < 0) {
         stop(
           glue::glue("ERROR: Requires RStudio Connect server version >= ",
             self$minimum_server_version,

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -2,17 +2,23 @@ context("connect")
 
 test_that("should require server (if no CONNECT_SERVER)", {
   local_server_stub()
-  expect_error(
-    connect(api_key = "fake"),
-    "valid server"
+  withr::with_envvar(
+    c(CONNECT_SERVER = NA),
+    expect_error(
+      connect(api_key = "fake"),
+      "valid server"
+    )
   )
 })
 
 test_that("should require api_key (if no CONNECT_API_KEY)", {
   local_server_stub()
-  expect_error(
-    connect(server = "http://example.com"),
-    "valid API key"
+  withr::with_envvar(
+    c(CONNECT_API_KEY = NA),
+    expect_error(
+      connect(server = "http://example.com"),
+      "valid API key"
+    )
   )
 })
 
@@ -72,5 +78,13 @@ test_that("should require minumum RStudio Connect server version", {
   expect_error(
     connect(server = "https://example.com", api_key = "fake"),
     "server version"
+  )
+})
+
+test_that("should warn when RStudio Connect server version is empty", {
+  local_server_stub(version = "")
+  expect_warning(
+    connect(server = "https://example.com", api_key = "fake"),
+    "server did not provide its version"
   )
 })


### PR DESCRIPTION
additionally, test-connect.R is no longer sensitive to incoming environment variables.

Given a Connect server configured with `Server.HideVersion = true`:

```
connectwidgets::connect()
#> RStudio Connect API Client: 
#>   Server: XXXXXX
#>   API Key: YYYYYY
#> Warning message:
#> In private$validate() :
#>   Unable to validate that the RStudio Connect server version >= 1.8.8.3; the server did not provide its version.
```

fixes #63