### PR TITLE
Changes for upcoming htmlwidgets 1.6 release

### DIFF
--- a/R/rsc_card.R
+++ b/R/rsc_card.R
@@ -52,12 +52,12 @@ rsc_card <- function(content) {
 #' Called by HTMLWidgets to produce the widget's root element.
 #' @noRd
 widget_html.rsc_card <- function(id, style, class, ...) {
-  htmltools::tagList(
+  htmltools::tags$div(
+    id = id, class = class, style = style,
     # Necessary for RStudio viewer version < 1.2
     reactR::html_dependency_corejs(),
     reactR::html_dependency_react(),
-    reactR::html_dependency_reacttools(),
-    htmltools::tags$div(id = id, class = class, style = style)
+    reactR::html_dependency_reacttools()
   )
 }
 

--- a/R/rsc_filter.R
+++ b/R/rsc_filter.R
@@ -66,12 +66,12 @@ rsc_filter <- function(content) {
 #' Called by HTMLWidgets to produce the widget's root element.
 #' @noRd
 widget_html.rsc_filter <- function(id, style, class, ...) {
-  htmltools::tagList(
+  htmltools::tags$div(
+    id = id, class = class, style = style,
     # Necessary for RStudio viewer version < 1.2
     reactR::html_dependency_corejs(),
     reactR::html_dependency_react(),
-    reactR::html_dependency_reacttools(),
-    htmltools::tags$div(id = id, class = class, style = style)
+    reactR::html_dependency_reacttools()
   )
 }
 

--- a/R/rsc_grid.R
+++ b/R/rsc_grid.R
@@ -72,12 +72,12 @@ rsc_grid <- function(content) {
 #' Called by HTMLWidgets to produce the widget's root element.
 #' @noRd
 widget_html.rsc_grid <- function(id, style, class, ...) {
-  htmltools::tagList(
+  htmltools::tags$div(
+    id = id, class = class, style = style,
     # Necessary for RStudio viewer version < 1.2
     reactR::html_dependency_corejs(),
     reactR::html_dependency_react(),
-    reactR::html_dependency_reacttools(),
-    htmltools::tags$div(id = id, class = class, style = style)
+    reactR::html_dependency_reacttools()
   )
 }
 

--- a/R/rsc_search.R
+++ b/R/rsc_search.R
@@ -65,12 +65,12 @@ rsc_search <- function(content) {
 #' Called by HTMLWidgets to produce the widget's root element.
 #' @noRd
 widget_html.rsc_search <- function(id, style, class, ...) {
-  htmltools::tagList(
+  htmltools::tags$div(
+    id = id, class = class, style = style,
     # Necessary for RStudio viewer version < 1.2
     reactR::html_dependency_corejs(),
     reactR::html_dependency_react(),
-    reactR::html_dependency_reacttools(),
-    htmltools::tags$div(id = id, class = class, style = style)
+    reactR::html_dependency_reacttools()
   )
 }
 

--- a/tests/testthat/test-rsc_card.R
+++ b/tests/testthat/test-rsc_card.R
@@ -112,10 +112,10 @@ test_that("rsccardOutput", {
   expect_true(length(deps) > 0)
 
   # Output container should have data-reactable-output ID set
-  expect_equal(output[[1]][[4]]$name, "div")
-  expect_equal(output[[1]][[4]]$attribs$id, "myrsccardid")
-  expect_equal(
-    output[[1]][[4]]$attribs$class,
-    "rsc_card html-widget html-widget-output"
-  )
+  name <- output[[1]]$name
+  id <- htmltools::tagGetAttribute(output[[1]], "id")
+  cls <- htmltools::tagGetAttribute(output[[1]], "class")
+  expect_equal(name, "div")
+  expect_equal(id, "myrsccardid")
+  expect_match(cls, "rsc_card html-widget html-widget-output")
 })

--- a/tests/testthat/test-rsc_filter.R
+++ b/tests/testthat/test-rsc_filter.R
@@ -93,10 +93,10 @@ test_that("rscfilterOutput", {
   expect_true(length(deps) > 0)
 
   # Output container should have data-reactable-output ID set
-  expect_equal(output[[1]][[4]]$name, "div")
-  expect_equal(output[[1]][[4]]$attribs$id, "myfilterid")
-  expect_equal(
-    output[[1]][[4]]$attribs$class,
-    "rsc_filter html-widget html-widget-output"
-  )
+  name <- output[[1]]$name
+  id <- htmltools::tagGetAttribute(output[[1]], "id")
+  cls <- htmltools::tagGetAttribute(output[[1]], "class")
+  expect_equal(name, "div")
+  expect_equal(id, "myfilterid")
+  expect_match(cls, "rsc_filter html-widget html-widget-output")
 })

--- a/tests/testthat/test-rsc_grid.R
+++ b/tests/testthat/test-rsc_grid.R
@@ -131,10 +131,10 @@ test_that("rscgridOutput", {
   expect_true(length(deps) > 0)
 
   # Output container should have data-reactable-output ID set
-  expect_equal(output[[1]][[4]]$name, "div")
-  expect_equal(output[[1]][[4]]$attribs$id, "mygridz")
-  expect_equal(
-    output[[1]][[4]]$attribs$class,
-    "rsc_grid html-widget html-widget-output"
-  )
+  name <- output[[1]]$name
+  id <- htmltools::tagGetAttribute(output[[1]], "id")
+  cls <- htmltools::tagGetAttribute(output[[1]], "class")
+  expect_equal(name, "div")
+  expect_equal(id, "mygridz")
+  expect_match(cls, "rsc_grid html-widget html-widget-output")
 })

--- a/tests/testthat/test-rsc_search.R
+++ b/tests/testthat/test-rsc_search.R
@@ -84,10 +84,10 @@ test_that("rscsearchOutput", {
   expect_true(length(deps) > 0)
 
   # Output container should have data-reactable-output ID set
-  expect_equal(output[[1]][[4]]$name, "div")
-  expect_equal(output[[1]][[4]]$attribs$id, "mysearch")
-  expect_equal(
-    output[[1]][[4]]$attribs$class,
-    "rsc_search html-widget html-widget-output"
-  )
+  name <- output[[1]]$name
+  id <- htmltools::tagGetAttribute(output[[1]], "id")
+  cls <- htmltools::tagGetAttribute(output[[1]], "class")
+  expect_equal(name, "div")
+  expect_equal(id, "mysearch")
+  expect_match(cls, "rsc_search html-widget html-widget-output")
 })


### PR DESCRIPTION
The upcoming [htmlwidgets 1.6 release](https://github.com/ramnathv/htmlwidgets/blob/master/NEWS.md) happens to break the unit tests that check the class of `htmlwidgets::shinyWidgetOutput()` (the new release will add some additional classes). Updating those expectations to use `expect_match()` instead of `expect_equal()` will get them passing with the new release. 

Also, with htmlwidgets 1.6, `rsc*Output()` now throws a warning because they return a `tagList()` (which won't work for the new `fill` parameters). And since it seems like you don't need to use `tagList()` here and can instead just include the extra dependencies in the `<div>`, I made that change as well 

