### PR TITLE
Update pkgdown GitHub action (and explicitly ignore topics)

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,48 +1,38 @@
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
 
 name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v1
-
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Restore R package cache
-        uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          install.packages("pkgdown", type = "binary")
-        shell: Rscript {0}
+          use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
 
       - name: Install package
         run: R CMD INSTALL .
 
-      - name: Deploy package
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name == 'release'
+        run: pkgdown::deploy_to_branch(new_process = FALSE)
+        shell: Rscript {0}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 .Renviron
 docs
+pkgdown
 node_modules
 inst/doc
 connectwidgets_*.tar.gz

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -18,3 +18,21 @@ reference:
   - rsc_search
   - rsc_filter
   - rsc_cols
+- title: "internal"
+- contents:
+  - Client
+  - connectwidgets
+  - default_theme
+  - evaluate_widget_input
+  - gen_theme_dependency
+  - get_bootswatch_theme_name
+  - get_current_bootswatch_theme
+  - get_user_provided_theme
+  - resolve_theme_dependency
+  - rsc_table_sync_theme
+  - warning_large_content
+  - warning_widget_input
+  - rsc_card-shiny
+  - rsc_filter-shiny
+  - rsc_grid-shiny
+  - rsc_search-shiny


### PR DESCRIPTION
Update the pkgdown.yaml GitHub action to be comparable to the currently distributed one from [rlib/actions](https://github.com/r-lib/actions/blob/v2/examples/pkgdown.yaml).  Also, recent versions of pkgdown also require topics to be explictly excluded within `_pkgdown.yaml` using `title: internal`.