### PR TITLE
Do not warn on Posit Connect versions that include dev versioning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,8 +40,7 @@ Imports:
     reactR,
     purrr,
     bslib,
-    sass,
-    stringr
+    sass
 URL:
     https://rstudio.github.io/connectwidgets/,
     https://github.com/rstudio/connectwidgets

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,8 @@ Imports:
     reactR,
     purrr,
     bslib,
-    sass
+    sass,
+    stringr
 URL:
     https://rstudio.github.io/connectwidgets/,
     https://github.com/rstudio/connectwidgets

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# UNRELEASED
+
+* Fixed broken grid view with bslib >= 0.4.x (#72)
+* Development versions of Connect no longer generate warnings when using
+  `connect` (#44)
+
 # connectwidgets 0.2.0
 
 * Add support for htmlwidgets 1.6 (#79)

--- a/R/connect.R
+++ b/R/connect.R
@@ -92,13 +92,17 @@ Client <- R6::R6Class( # nolint
             "; the server did not provide its version."
           )
         )
-      } else if (compareVersion(settings$version, self$minimum_server_version) < 0) {
-        stop(
-          glue::glue("ERROR: Requires Posit Connect server version >= ",
-            self$minimum_server_version,
-            ", current version ",
-            settings$version)
-        )
+      } else {
+        parsed_version <- stringr::str_split_i(settings$version, "-", 1)
+
+        if (compareVersion(parsed_version, self$minimum_server_version) < 0) {
+          stop(
+            glue::glue("ERROR: Requires Posit Connect server version >= ",
+              self$minimum_server_version,
+              ", current version ",
+              settings$version)
+          )
+        }
       }
     },
     raise_error = function(res) {

--- a/R/connect.R
+++ b/R/connect.R
@@ -93,7 +93,8 @@ Client <- R6::R6Class( # nolint
           )
         )
       } else {
-        parsed_version <- stringr::str_split_i(settings$version, "-", 1)
+        # Drop the -dev version suffix, if present
+        parsed_version <- sub("-.*$", "", settings$version)
 
         if (compareVersion(parsed_version, self$minimum_server_version) < 0) {
           stop(

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -88,3 +88,10 @@ test_that("should warn when Posit Connect server version is empty", {
     "server did not provide its version"
   )
 })
+
+test_that("should strip dev versioning artifacts from Posit Connect server version", {
+  local_server_stub(version = "2023.10.0-dev+3")
+  expect_no_warning(
+    connect(server = "https://example.com", api_key = "fake")
+  )
+})


### PR DESCRIPTION
When comparing server version against minimum version, let's just strip everything after the `-`.  This is a no-op if there is no `-` in the version.

Fixes #44